### PR TITLE
Fix mixin configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ jar {
     }
 
     manifest {
-        attributes "FMLCorePlugin": mod_core_plugin
+        attributes "FMLCorePlugin": mod_core_plugin.replace('${mod_group}', mod_group)
         attributes "FMLCorePluginContainsFMLMod": "true"
         attributes "ForceLoadAsMod": "true"
         attributes "TweakClass": "org.spongepowered.asm.launch.MixinTweaker"

--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,10 @@ processResources {
     }
 }
 
+mixin {
+    add sourceSets.main, mod_mixin_refmap.replace('${mod_id}', mod_id)
+}
+
 jar {
     from(configurations.provided.collect {
         it.isDirectory() ? it : zipTree(it)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,3 +9,4 @@ forge_version=14.23.5.2847
 mappings_version=snapshot_20180814
 mod_core_plugin=${mod_group}.core.CoreMod
 mod_mixin_configs=mixins.${mod_id}.json
+mod_mixin_refmap=refmap.${mod_id}.json

--- a/src/main/resources/mixins.example.json
+++ b/src/main/resources/mixins.example.json
@@ -1,7 +1,7 @@
 {
   "compatibilityLevel": "JAVA_8",
   "package": "com.yourname.modid.mixin",
-  "refmap": "change_to_your_modid.refmap.json",
+  "refmap": "refmap.change_to_your_modid.json",
   "mixins": [],
   "client": [
     "MixinMinecraft"

--- a/src/main/resources/mixins.example.json
+++ b/src/main/resources/mixins.example.json
@@ -1,9 +1,10 @@
 {
   "compatibilityLevel": "JAVA_8",
   "package": "com.yourname.modid.mixin",
-  "mixins": [
+  "refmap": "change_to_your_modid.refmap.json",
+  "mixins": [],
+  "client": [
     "MixinMinecraft"
   ],
-  "client": [],
   "server": []
 }


### PR DESCRIPTION
Using the default refmap settings will cause refmap conflict with other mods (related issue: https://github.com/Snownee/MiniEffects/issues/1)