### PR TITLE
Improve buildscript, and tweak coremod

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,11 +32,11 @@ minecraft {
             workingDirectory project.file('run')
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
-            property 'fml.coreMods.load', '${mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)}'
+            property 'fml.coreMods.load', mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)
         }
 
         server {
-            property 'fml.coreMods.load', '${mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)}'
+            property 'fml.coreMods.load', mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -27,20 +27,16 @@ minecraft {
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
     // accessTransformer = file('src/main/resources/META-INF/accesstransformer.cfg')
 
-    String myJvmArgs = "-Dfml.coreMods.load=${mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)}"
-    String myRunArgs = "--mixin ${mod_mixin_configs.replace('${mod_id}', mod_id)}"
     runs {
         client {
-            args = [myRunArgs]
-            jvmArgs = [myJvmArgs]
             workingDirectory project.file('run')
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
+            property 'fml.coreMods.load', '${mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)}'
         }
 
         server {
-            args = [myRunArgs]
-            jvmArgs = [myJvmArgs]
+            property 'fml.coreMods.load', '${mod_core_plugin.replace('${mod_group}', mod_group).replace('${mod_id}', mod_id)}'
             property 'forge.logging.markers', 'SCAN,REGISTRIES,REGISTRYDUMP'
             property 'forge.logging.console.level', 'debug'
         }

--- a/src/main/java/com/yourname/modid/core/CoreMod.java
+++ b/src/main/java/com/yourname/modid/core/CoreMod.java
@@ -2,16 +2,16 @@ package com.yourname.modid.core;
 
 import net.minecraftforge.fml.relauncher.IFMLLoadingPlugin;
 import org.spongepowered.asm.launch.MixinBootstrap;
+import org.spongepowered.asm.mixin.MixinEnvironment;
+import org.spongepowered.asm.mixin.Mixins;
+import com.yourname.modid.Example;
 
 import javax.annotation.Nullable;
 import java.util.Map;
 
+@IFMLLoadingPlugin.MCVersion("1.12.2")
 @IFMLLoadingPlugin.Name("YourModName")
 public class CoreMod implements IFMLLoadingPlugin {
-
-    public CoreMod() {
-        MixinBootstrap.init();
-    }
 
     @Override
     public String[] getASMTransformerClass() {
@@ -31,6 +31,9 @@ public class CoreMod implements IFMLLoadingPlugin {
 
     @Override
     public void injectData(Map<String, Object> data) {
+        MixinBootstrap.init();
+        Mixins.addConfiguration("mixins." + Example.MOD_ID + ".json");
+        MixinEnvironment.getDefaultEnvironment().setObfuscationContext("searge");
     }
 
     @Override


### PR DESCRIPTION
I have changed the buildscript to add the coremod to JVM args in a much cleaner way,
and I also removed the need to add the mixin configuration to the run arguments, buy telling mixin to use the right config in the coremod when you initialize it.