### PR TITLE
Add refmap to mixins config

### DIFF
--- a/src/main/resources/mixins.example.json
+++ b/src/main/resources/mixins.example.json
@@ -1,6 +1,7 @@
 {
   "compatibilityLevel": "JAVA_8",
   "package": "com.yourname.modid.mixin",
+  "refmap": "refmap.example.json",
   "mixins": [
     "MixinMinecraft"
   ],


### PR DESCRIPTION
Before @Injections would only work in the dev environment but not when build and loaded outside of Intellij