### PR TITLE
fix Unsupported class file major version 60

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ configurations {
 dependencies {
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    embed('org.spongepowered:mixin:0.8.5-SNAPSHOT') {
+    implementation('org.spongepowered:mixin:0.8.5-SNAPSHOT') {
         exclude module: 'guava'
         exclude module: 'commons-io'
         exclude module: 'gson'


### PR DESCRIPTION
reobf

```
> Task :reobfJar FAILED
Exception in thread "main" java.lang.IllegalArgumentException: Unsupported class file major version 60
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:166)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:148)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:136)
	at org.objectweb.asm.ClassReader.<init>(ClassReader.java:237)
	at net.md_5.specialsource.JarRemapper.remapClassFile(JarRemapper.java:221)
	at net.md_5.specialsource.JarRemapper.remapJar(JarRemapper.java:187)
	at net.md_5.specialsource.SpecialSource.main(SpecialSource.java:273)

FAILURE: Build failed with an exception.
```